### PR TITLE
Fix Windows 10 icon not shown

### DIFF
--- a/src/NotifierPlugin.php
+++ b/src/NotifierPlugin.php
@@ -94,7 +94,7 @@ class NotifierPlugin implements PluginInterface, EventSubscriberInterface
             (new Notification())
                 ->setTitle($this->getProjectName())
                 ->setBody($body)
-                ->setIcon(__DIR__ . '/../Resources/logo.png')
+                ->setIcon(realpath(__DIR__ . '/../Resources/logo.png'))
         ;
 
         $this->notifier->send($notification);


### PR DESCRIPTION
Windows 10 x64 doesn't show the icon when the path contains `..`. Using `realpath `function fixes the problem.

This commit closes #3